### PR TITLE
Enable throttling on graphql

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -9,7 +9,7 @@ class Rack::Attack
   # safelisting). It must implement .increment and .write like
   # ActiveSupport::Cache::Store
 
-  # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+  Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
 
   # Throttle graphql requests by ip
 

--- a/spec/config/initializers/rack_attack_spec.rb
+++ b/spec/config/initializers/rack_attack_spec.rb
@@ -3,30 +3,32 @@ require "rails_helper"
 RSpec.describe Rack::Attack do
   include Rack::Test::Methods
 
-  def app
-    Rails.application
-  end
+  def app = Rails.application
+
+  before { Rack::Attack.reset! }
 
   describe "throttle excessive qraphql requests by IP address" do
     let(:limit) { 1000 }
 
-    context "number of requests is lower than the limit" do
+    context "when the number of requests is equal to or lower than the limit" do
+      before do
+        (limit - 1).times { post "/graphql", {}, "REMOTE_ADDR" => "1.2.3.5" }
+      end
+
       it "does not change the request status" do
-        limit.times do
-          post "/graphql", {}, "REMOTE_ADDR" => "1.2.3.4"
-          expect(last_response.status).to_not eq(429)
-        end
+        post "/graphql", {}, "REMOTE_ADDR" => "1.2.3.4"
+        expect(last_response.status).to_not eq(429)
       end
     end
 
-    # I was unable to get this spec working with the time limit
-    xcontext "number of requests is higher than the limit" do
-      let(:limit) { 1250 }
+    context "number of requests is higher than the limit" do
+      before do
+        limit.times { post "/graphql", {}, "REMOTE_ADDR" => "1.2.3.5" }
+      end
+
       it "changes the request status to 429" do
-        limit.times do |i|
-          post "/graphql", {}, "REMOTE_ADDR" => "1.2.3.5"
-          expect(last_response.status).to eq(429) if i > 1000
-        end
+        post "/graphql", {}, "REMOTE_ADDR" => "1.2.3.5"
+        expect(last_response.status).to eq(429)
       end
     end
   end


### PR DESCRIPTION
Cache needs to be enabled for throttling to work.